### PR TITLE
#21 Use crossplatform desktop API to open files

### DIFF
--- a/EasyGecNG/src/main/java/ihm/IhmEasyGec.java
+++ b/EasyGecNG/src/main/java/ihm/IhmEasyGec.java
@@ -59,6 +59,7 @@ import outils.FiltreFichier;
 import outils.Outils;
 import outils.TaskBoutonOkNok;
 import outils.TimeManager;
+import outils.DesktopApi;
 
 import java.awt.event.ActionListener;
 import java.awt.event.ActionEvent;
@@ -940,21 +941,9 @@ public class IhmEasyGec extends JFrame
     {
       public void actionPerformed(ActionEvent arg0) 
       {
-        //enregistreResultats();
-        // Lancement du fichier
-        Runtime r = Runtime.getRuntime();
-        
-        try
-        {
-          // Lancement du fichier d'aide de l'application
-          String adresse = new File(".").getCanonicalPath().toString();
-          adresse = "cmd /c start \"\" \""  + easyGec.getFichier().substring(0, easyGec.getFichier().length()-4) + EasyGec.getLangages().getText("114", EasyGec.getLang()) + ".html" +"\"";
-          r.exec(adresse);
-        }
-        catch (IOException e1)
-        {
-          JOptionPane.showMessageDialog(null,"Erreur de lancement du fichier : "+e1.getClass().getName());
-        }
+        // Lancement du fichier d'aide de l'application
+        String adresse = easyGec.getFichier().substring(0, easyGec.getFichier().length()-4) + EasyGec.getLangages().getText("114", EasyGec.getLang()) + ".html";
+        DesktopApi.edit(new File(adresse));
       }
     });
     
@@ -1002,19 +991,8 @@ public class IhmEasyGec extends JFrame
       public void actionPerformed(ActionEvent e) 
       {
         // Lancement du fichier
-        Runtime r = Runtime.getRuntime();
-        
-        try
-        {
-          // Lancement du fichier d'aide de l'application
-          String adresse = new File(".").getCanonicalPath().toString();
-          adresse = "cmd /c start \"\" \""  + easyGec.getFichier().substring(0, easyGec.getFichier().length()-4) + EasyGec.getLangages().getText("113", EasyGec.getLang()) + ".html" +"\"";
-          r.exec(adresse);
-        }
-        catch (IOException e1)
-        {
-          JOptionPane.showMessageDialog(null,"Erreur de lancement du fichier : "+e1.getClass().getName());
-        }
+        String adresse = easyGec.getFichier().substring(0, easyGec.getFichier().length()-4) + EasyGec.getLangages().getText("113", EasyGec.getLang()) + ".html";
+        DesktopApi.edit(new File(adresse));
       }
     });
     btnResultatsGlobaux.setIcon(new ImageIcon(IhmEasyGec.class.getResource("/icones/podium.png")));
@@ -1026,20 +1004,9 @@ public class IhmEasyGec extends JFrame
     {
       public void actionPerformed(ActionEvent e) 
       {
-        // Lancement du fichier
-        Runtime r = Runtime.getRuntime();
-        
-        try
-        {
-          // Lancement du fichier d'aide de l'application
-          String adresse = new File(".").getCanonicalPath().toString();
-          adresse = "cmd /c start \"\" \""  + easyGec.getFichier().substring(0, easyGec.getFichier().length()-4) + EasyGec.getLangages().getText("115", EasyGec.getLang()) + ".html" +"\"";
-          r.exec(adresse);
-        }
-        catch (IOException e1)
-        {
-          JOptionPane.showMessageDialog(null,"Erreur de lancement du fichier : "+e1.getClass().getName());
-        }
+        // Lancement du fichier d'aide de l'application
+        String adresse = easyGec.getFichier().substring(0, easyGec.getFichier().length()-4) + EasyGec.getLangages().getText("115", EasyGec.getLang()) + ".html";
+        DesktopApi.edit(new File(adresse));
       }
     });
     btnResultatsDetailled.setIcon(new ImageIcon(IhmEasyGec.class.getResource("/icones/chrono.png")));
@@ -1055,22 +1022,9 @@ public class IhmEasyGec extends JFrame
     {
       public void actionPerformed(ActionEvent arg0) 
       {
-        //enregistreResultatsDetailles();
-
-        // Lancement du fichier
-        Runtime r = Runtime.getRuntime();
-        
-        try
-        {
-          // Lancement du fichier d'aide de l'application
-          String adresse = new File(".").getCanonicalPath().toString();
-          adresse = "cmd /c start \"\" \""  + easyGec.getFichier().substring(0, easyGec.getFichier().length()-4) + EasyGec.getLangages().getText("117", EasyGec.getLang()) + ".html" +"\"";
-          r.exec(adresse);
-        }
-        catch (IOException e1)
-        {
-          JOptionPane.showMessageDialog(null,"Erreur de lancement du fichier : "+e1.getClass().getName());
-        }
+        // Lancement du fichier d'aide de l'application
+        String adresse = easyGec.getFichier().substring(0, easyGec.getFichier().length()-4) + EasyGec.getLangages().getText("117", EasyGec.getLang()) + ".html";
+        DesktopApi.edit(new File(adresse));
       }
     });
     panel.add(btnExportPartiels);
@@ -1128,14 +1082,12 @@ public class IhmEasyGec extends JFrame
     {
       public void actionPerformed(ActionEvent arg0) 
       {
-        Runtime r = Runtime.getRuntime();
-        
         try
         {
           // Lancement du fichier d'aide de l'application
           String adresse = new File(".").getCanonicalPath().toString();
-          adresse = "cmd /c start \"\" \"" + adresse + "/" + EasyGec.getLangages().getText("0", EasyGec.getLang()) +"\"";
-          r.exec(adresse);
+          adresse = adresse + "/" + EasyGec.getLangages().getText("0", EasyGec.getLang());
+          DesktopApi.edit(new File(adresse));
         }
         catch (IOException e1)
         {

--- a/EasyGecNG/src/main/java/ihm/IhmMappage.java
+++ b/EasyGecNG/src/main/java/ihm/IhmMappage.java
@@ -8,6 +8,7 @@ import java.awt.BorderLayout;
 import javax.swing.JTable;
 
 import metier.EasyGec;
+import outils.DesktopApi;
 
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
@@ -119,15 +120,13 @@ public class IhmMappage extends javax.swing.JDialog
       public void actionPerformed(ActionEvent e) 
       {
         CsvMappageCourant.exporter(easyGec, easyGec.getMappagesCourant().getNom() + ".csv");
-        // Lancement du fichier
-        Runtime r = Runtime.getRuntime();
         
         try
         {
           // Lancement du fichier d'aide de l'application
           String adresse = new File(".").getCanonicalPath().toString();
-          adresse = "cmd /c start \"\" \"" + adresse + "/" + easyGec.getMappagesCourant().getNom() + ".csv" +"\"";
-          r.exec(adresse);
+          adresse = adresse + "/" + easyGec.getMappagesCourant().getNom() + ".csv";
+          DesktopApi.edit(new File(adresse));
         }
         catch (IOException e1)
         {

--- a/EasyGecNG/src/main/java/outils/DesktopApi.java
+++ b/EasyGecNG/src/main/java/outils/DesktopApi.java
@@ -1,0 +1,209 @@
+package outils;
+
+import java.awt.Desktop;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+// Courtesy of MightyPork: https://stackoverflow.com/questions/18004150/desktop-api-is-not-supported-on-the-current-platform
+public class DesktopApi {
+
+    public static boolean browse(URI uri) {
+        // Try system-specific, then awt.Desktop
+        return openSystemSpecific(uri.toString()) || browseDESKTOP(uri);
+    }
+    
+    
+    public static boolean open(File file) {
+        // Try system-specific, then awt.Desktop
+        return openSystemSpecific(file.getPath()) || openDESKTOP(file);
+    }
+    
+    
+    public static boolean edit(File file) {
+        // Try system-specific, then awt.Desktop
+
+        // you can try something like
+        // runCommand("gimp", "%s", file.getPath())
+        // based on user preferences.
+
+        return openSystemSpecific(file.getPath()) || editDESKTOP(file);
+    }
+
+
+    private static boolean openSystemSpecific(String what) {
+
+        EnumOS os = getOs();
+
+        if (os.isLinux()) {
+            if (runCommand("kde-open", "%s", what)) return true;
+            if (runCommand("gnome-open", "%s", what)) return true;
+            if (runCommand("xdg-open", "%s", what)) return true;
+        }
+
+        if (os.isMac()) {
+            if (runCommand("open", "%s", what)) return true;
+        }
+
+        if (os.isWindows()) {
+            if (runCommand("explorer", "%s", what)) return true;
+        }
+
+        return false;
+    }
+
+
+    private static boolean browseDESKTOP(URI uri) {
+        try {
+            if (!Desktop.isDesktopSupported()) {
+                return false;
+            }
+
+            if (!Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                return false;
+            }
+
+            Desktop.getDesktop().browse(uri);
+
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+
+    private static boolean openDESKTOP(File file) {
+
+        try {
+            if (!Desktop.isDesktopSupported()) {
+                return false;
+            }
+
+            if (!Desktop.getDesktop().isSupported(Desktop.Action.OPEN)) {
+                return false;
+            }
+
+            Desktop.getDesktop().open(file);
+
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+
+    private static boolean editDESKTOP(File file) {
+
+        try {
+            if (!Desktop.isDesktopSupported()) {
+                return false;
+            }
+
+            if (!Desktop.getDesktop().isSupported(Desktop.Action.EDIT)) {
+                return false;
+            }
+
+            Desktop.getDesktop().edit(file);
+
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+
+    private static boolean runCommand(String command, String args, String file) {
+
+        String[] parts = prepareCommand(command, args, file);
+
+        try {
+            Process p = Runtime.getRuntime().exec(parts);
+            if (p == null) return false;
+
+            try {
+                int retval = p.exitValue();
+                if (retval == 0) {
+                    return false;
+                } else {
+                    return false;
+                }
+            } catch (IllegalThreadStateException itse) {
+                return true;
+            }
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+
+    private static String[] prepareCommand(String command, String args, String file) {
+
+        List<String> parts = new ArrayList<String>();
+        parts.add(command);
+
+        if (args != null) {
+            for (String s : args.split(" ")) {
+                s = String.format(s, file); // put in the filename thing
+
+                parts.add(s.trim());
+            }
+        }
+
+        return parts.toArray(new String[parts.size()]);
+    }
+
+    public static enum EnumOS {
+        linux, macos, solaris, unknown, windows;
+
+        public boolean isLinux() {
+
+            return this == linux || this == solaris;
+        }
+
+
+        public boolean isMac() {
+
+            return this == macos;
+        }
+
+
+        public boolean isWindows() {
+
+            return this == windows;
+        }
+    }
+
+
+    public static EnumOS getOs() {
+
+        String s = System.getProperty("os.name").toLowerCase();
+
+        if (s.contains("win")) {
+            return EnumOS.windows;
+        }
+
+        if (s.contains("mac")) {
+            return EnumOS.macos;
+        }
+
+        if (s.contains("solaris")) {
+            return EnumOS.solaris;
+        }
+
+        if (s.contains("sunos")) {
+            return EnumOS.solaris;
+        }
+
+        if (s.contains("linux")) {
+            return EnumOS.linux;
+        }
+
+        if (s.contains("unix")) {
+            return EnumOS.linux;
+        } else {
+            return EnumOS.unknown;
+        }
+    }
+}

--- a/EasyGecNG/src/main/java/outils/DesktopApi.java
+++ b/EasyGecNG/src/main/java/outils/DesktopApi.java
@@ -14,14 +14,14 @@ public class DesktopApi {
         // Try system-specific, then awt.Desktop
         return openSystemSpecific(uri.toString()) || browseDESKTOP(uri);
     }
-    
-    
+
+
     public static boolean open(File file) {
         // Try system-specific, then awt.Desktop
         return openSystemSpecific(file.getPath()) || openDESKTOP(file);
     }
-    
-    
+
+
     public static boolean edit(File file) {
         // Try system-specific, then awt.Desktop
 
@@ -56,12 +56,16 @@ public class DesktopApi {
 
 
     private static boolean browseDESKTOP(URI uri) {
+
+        logOut("Trying to use Desktop.getDesktop().browse() with " + uri.toString());
         try {
             if (!Desktop.isDesktopSupported()) {
+                logErr("Platform is not supported.");
                 return false;
             }
 
             if (!Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                logErr("BROWSE is not supported.");
                 return false;
             }
 
@@ -69,6 +73,7 @@ public class DesktopApi {
 
             return true;
         } catch (Throwable t) {
+            logErr("Error using desktop browse.", t);
             return false;
         }
     }
@@ -76,12 +81,15 @@ public class DesktopApi {
 
     private static boolean openDESKTOP(File file) {
 
+        logOut("Trying to use Desktop.getDesktop().open() with " + file.toString());
         try {
             if (!Desktop.isDesktopSupported()) {
+                logErr("Platform is not supported.");
                 return false;
             }
 
             if (!Desktop.getDesktop().isSupported(Desktop.Action.OPEN)) {
+                logErr("OPEN is not supported.");
                 return false;
             }
 
@@ -89,6 +97,7 @@ public class DesktopApi {
 
             return true;
         } catch (Throwable t) {
+            logErr("Error using desktop open.", t);
             return false;
         }
     }
@@ -96,12 +105,15 @@ public class DesktopApi {
 
     private static boolean editDESKTOP(File file) {
 
+        logOut("Trying to use Desktop.getDesktop().edit() with " + file);
         try {
             if (!Desktop.isDesktopSupported()) {
+                logErr("Platform is not supported.");
                 return false;
             }
 
             if (!Desktop.getDesktop().isSupported(Desktop.Action.EDIT)) {
+                logErr("EDIT is not supported.");
                 return false;
             }
 
@@ -109,12 +121,15 @@ public class DesktopApi {
 
             return true;
         } catch (Throwable t) {
+            logErr("Error using desktop edit.", t);
             return false;
         }
     }
 
 
     private static boolean runCommand(String command, String args, String file) {
+
+        logOut("Trying to exec:\n   cmd = " + command + "\n   args = " + args + "\n   %s = " + file);
 
         String[] parts = prepareCommand(command, args, file);
 
@@ -125,14 +140,18 @@ public class DesktopApi {
             try {
                 int retval = p.exitValue();
                 if (retval == 0) {
+                    logErr("Process ended immediately.");
                     return false;
                 } else {
+                    logErr("Process crashed.");
                     return false;
                 }
             } catch (IllegalThreadStateException itse) {
+                logErr("Process is running.");
                 return true;
             }
         } catch (IOException e) {
+            logErr("Error running command.", e);
             return false;
         }
     }
@@ -152,6 +171,19 @@ public class DesktopApi {
         }
 
         return parts.toArray(new String[parts.size()]);
+    }
+
+    private static void logErr(String msg, Throwable t) {
+        System.err.println(msg);
+        t.printStackTrace();
+    }
+
+    private static void logErr(String msg) {
+        System.err.println(msg);
+    }
+
+    private static void logOut(String msg) {
+        System.out.println(msg);
     }
 
     public static enum EnumOS {


### PR DESCRIPTION
Unfortunately, the official `java.awt.Desktop` API is not fully functional on all platforms. Instead, we use the `DesktopApi` class provided by MightyPork [here](https://stackoverflow.com/questions/18004150/desktop-api-is-not-supported-on-the-current-platform). This uses system-specific commands instead of the one windows specific command, and falls back to `java.awt.Desktop` if all of them fail.

Note that this does still leave us open to injection attacks.

Resolves #21